### PR TITLE
realme-ota: Track OTA's from IN Server too

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -c SERVER, --server SERVER
-                        Use specific server for the request (GL = 0, CN = 1).
+                        Use specific server for the request (GL = 0, CN = 1, IN = 2).
   -i IMEI, --imei IMEI  Use custom IMEI for the request.
   -t TIMEOUT, --timeout TIMEOUT
                         Use custom timeout for the request.

--- a/realme_ota/main.py
+++ b/realme_ota/main.py
@@ -25,7 +25,7 @@ def main():
     parser = ArgumentParser()
     parser.add_argument("product_model", help="Product Model (ro.product.name).")
     parser.add_argument("ota_version", help="OTA Version (ro.build.version.ota).")
-    parser.add_argument("-c", "--server", type=int, default=0, help="Use specific server for the request (GL = 0, CN = 1).")
+    parser.add_argument("-c", "--server", type=int, default=0, help="Use specific server for the request (GL = 0, CN = 1, IN = 2).")
     parser.add_argument("-i", "--imei", type=int, help="Use custom IMEI for the request.")
     parser.add_argument("-t", "--timeout", type=int, help="Use custom timeout for the request.")
     parser.add_argument("-a", "--android", type=str, help="Use custom android version for the request.")
@@ -52,6 +52,8 @@ def main():
     
     if args.server == 1:
         URL = config.CN_URL
+    if args.server ==2:
+        URL = config.IN_URL
     if args.timeout:
         TIMEOUT = args.timeout
     

--- a/realme_ota/utils/config.py
+++ b/realme_ota/utils/config.py
@@ -1,6 +1,7 @@
 # Realme endpoints
 GL_URL = "https://ifota.realmemobile.com/post/Query_Update"
 CN_URL = "https://iota.coloros.com/post/Query_Update"
+IN_URL = "https://ifota-in.realmemobile.com/Query_Update"
 
 # Default timeout for requests
 TIMEOUT = 30


### PR DESCRIPTION
* OTA's from Indian Server can be tracked using , optional argument server -c or --server to '2' .