### PR TITLE
readme: Don't use sudo to install python packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ CLI tool (based on this [C# program](https://github.com/4j17h/realmeOTAUpdates))
 ## Installation
 ```bash
 sudo apt install python3-pip
-sudo pip3 install --upgrade pycryptodome git+https://github.com/R0rt1z2/realme-ota
+pip3 install --upgrade pycryptodome git+https://github.com/R0rt1z2/realme-ota
 ```
 
 ## Usage


### PR DESCRIPTION
There is no reason to install python packages as root. The package works when installed as root and when installed as user, so the documentation should default to a user installation to preserve security and avoid possible conflicts with system packages.