### PR TITLE
Code refactor, bug fixes, new options

### DIFF
--- a/realme_ota/main.py
+++ b/realme_ota/main.py
@@ -33,6 +33,8 @@ def main():
     req_opts = parser.add_argument_group("request options")
     req_opts.add_argument("-r", "--region", type=int, choices=[0, 1, 2, 3], default=0, help="Use custom region for the request (GL = 0, CN = 1, IN = 2, EU = 3).")
     req_opts.add_argument("-g", "--guid", type=str, default="0", help="The guid of the third line in the file /data/system/openid_config.xml (only required to extract 'CBT' in China).")
+    req_opts.add_argument("-i", "--imei", type=str, nargs='+', help="Specify one or two IMEIs for the request.")
+    req_opts.add_argument("-b", "--beta", action='store_true', help="Try to get a test version (IMEI probably required).")
     # Output settings
     out_opts = parser.add_argument_group("output options")
     out_opts.add_argument("-d", "--dump", type=str, help="Save request response into a file.")
@@ -50,7 +52,10 @@ def main():
         rui_version = args.rui_version,
         nv_identifier = args.nv_identifier,
         region = args.region,
-        deviceId = args.guid
+        deviceId = args.guid,
+        imei0 = args.imei[0] if args.imei and len(args.imei) > 0 else None,
+        imei1 = args.imei[1] if args.imei and len(args.imei) > 1 else None,
+        beta = args.beta
     )
 
     logger.log(f"Load payload for {args.product_model} (RealmeUI V{args.rui_version})")

--- a/realme_ota/utils/crypto.py
+++ b/realme_ota/utils/crypto.py
@@ -18,16 +18,17 @@ def encrypt_ctr(buf):
     key_pseudo = str(randint(0, 10)) + ''.join(choices(string.digits, k=14))
     key_real = getKey(key_pseudo)
 
-    ctr = Counter.new(128, initial_value=int.from_bytes(bytes.fromhex(hashlib.md5(key_real).hexdigest()), "big"))
+    ctr = Counter.new(128, initial_value=int.from_bytes(hashlib.md5(key_real).digest(), "big"))
     cipher = AES.new(key_real, AES.MODE_CTR, counter=ctr)
+    encrypted = cipher.encrypt(buf.encode("utf-8"))
 
-    return b64encode(cipher.encrypt(buf.encode("utf-8"))) + key_pseudo.encode("utf-8")
+    return b64encode(encrypted).decode('utf-8') + key_pseudo
 
 def decrypt_ctr(buf):
     data = b64decode(buf[:-15])
     key_real = getKey(buf[-15:])
 
-    ctr = Counter.new(128, initial_value=int.from_bytes(bytes.fromhex(hashlib.md5(key_real).hexdigest()), "big"))
+    ctr = Counter.new(128, initial_value=int.from_bytes(hashlib.md5(key_real).digest(), "big"))
     cipher = AES.new(key_real, AES.MODE_CTR, counter=ctr)
 
     return cipher.decrypt(data).decode("utf-8")

--- a/realme_ota/utils/data.py
+++ b/realme_ota/utils/data.py
@@ -11,6 +11,7 @@ default_headers = {
     'uRegion'        : 'unknown',          # persist.sys.oppo.region (RUI1)
     'trackRegion'    : 'unknown',          # ro.oppo.regionmark (RUI1)
     'imei'           : '000000000000000',  # IMEI
+    'imei1'          : '000000000000000',  # IMEI
     'deviceId'       : '0',                # N/A
     'mode'           : '0',                # N/A
     'Accept'         : 'application/json', # N/A
@@ -30,6 +31,7 @@ default_body = {
     'uRegion'        : 'unknown',          # persist.sys.oppo.region (RUI1)
     'trackRegion'    : 'unknown',          # ro.oppo.regionmark (RUI1)
     'imei'           : '000000000000000',  # IMEI
+    'imei1'          : '000000000000000',  # IMEI
     'mode'           : '0',                # N/A
     'registrationId' : 'unknown',          # N/A
     'deviceId'       : '0',                # N/A

--- a/realme_ota/utils/logger.py
+++ b/realme_ota/utils/logger.py
@@ -1,22 +1,21 @@
 import datetime
 
 LOGGING_LEVELS = {
-    "-1":"U", # Unknown (Default)
-    "0":"I",  # Info
-    "1":"W",  # Warning
-    "2":"E",  # Error
-    "3":"F",  # Fatal Error
-    "4":"D",  # Debug
-    "5":"V",  # Verbose
+    0:  "U",    # Unknown (Default)
+    1:  "F",    # Fatal Error
+    2:  "E",    # Error
+    3:  "W",    # Warning
+    4:  "I",    # Info
+    5:  "D",    # Debug
 }
 
 class Logger:
-    def __init__(self, silent = 0):
-        self.silent = silent
+    def __init__(self, level):
+        self.level = level if level in range(0, 6) else 4
 
-    def log(self, buf, prio = 0):
-        if not self.silent:
-            print(f"[{datetime.datetime.now()}] {LOGGING_LEVELS.get(prio, LOGGING_LEVELS[str(prio)])}: {buf}")
+    def log(self, buf, prio = 4):
+        if prio <= self.level:
+            print(f"[{datetime.datetime.now()}] {LOGGING_LEVELS.get(prio, LOGGING_LEVELS[0])}: {buf}")
 
     def die(self, msg, ecl):
         self.log(f"{msg}", ecl)

--- a/realme_ota/utils/request.py
+++ b/realme_ota/utils/request.py
@@ -8,103 +8,98 @@ except ImportError:
     from realme_ota.utils import crypto
 
 class Request:
-    def __init__(self, model, ota_version, nv_identifier, rui_version, region, deviceId):
-        self.model = model
-        self.productName = model
-        self.nvId = nv_identifier
-        self.otaVersion = ota_version
-        self.rui_version = rui_version
-        self.region = region
-        self.deviceId = deviceId
+    def __init__(self, model=None, ota_version=None, nv_identifier=None, rui_version=None, region=None, deviceId=None):
+        self.properties = {
+            'model': model,
+            'productName': model,
+            'nvId': nv_identifier,
+            'otaVersion': ota_version,
+            'rui_version': rui_version,
+            'region': region,
+            'deviceId': deviceId
+        }
         self.body = None
-        self.headers = None
+        self.headers = dict()
         self.url = None
 
     def encrypt(self, buf):
-        return (crypto.encrypt_ecb(buf) if self.rui_version <= 1 \
+        return (crypto.encrypt_ecb(buf) if self.properties.get('rui_version') <= 1 \
             else crypto.encrypt_ctr(buf))
 
     def decrypt(self, buf):
-        return (crypto.decrypt_ecb(buf) if self.rui_version <= 1 \
+        return (crypto.decrypt_ecb(buf) if self.properties.get('rui_version') <= 1 \
             else crypto.decrypt_ctr(buf))
 
     def set_vars(self):
+        region = self.properties.get('region')
+        rui_version = self.properties.get('rui_version')
+        nvId = self.properties.get('nvId')
+
         #
         # @name(s): trackRegion, uRegion
         # @value(s): ro.oppo.regionmark, persist.sys.oppo.region
         #
-        self.trackRegion = self.uRegion = {self.region == 1: 'CN',
-            self.region == 2: 'IN'}.get(True, 'GL')
+        self.properties['trackRegion'] = self.properties['uRegion'] = 'CN' if region == 1 else 'IN' if region == 2 else 'EU' if region == 3 else 'GL'
 
         #
         # @name(s): language
         # @value(s): LOCALE
         #
-        if self.region == 1:
-            self.language = 'zh-CN'
+        if region == 1:
+            self.properties['language'] = 'zh-CN'
 
         #
         # @name(s): androidVersion
         # @value(s): Android{Version}
         #
-        self.androidVersion = 'Android' + {self.rui_version == 1: '10.0',
-            self.rui_version == 2: '11.0'}.get(True, '12.0')
+        self.properties['androidVersion'] = 'Android' + ('10.0' if rui_version == 1 else '11.0' if rui_version == 2 else '12.0' if rui_version == 3 else '13.0')
 
         #
         # @name(s): colorOSVersion
         # @value(s): ColorOS{Version}
         #
-        self.colorOSVersion = 'ColorOS' + {self.rui_version == 1: '7',
-            self.rui_version == 2: '11'}.get(True, '12')
+        self.properties['colorOSVersion'] = 'ColorOS' + ('7' if rui_version == 1 else '11' if rui_version == 2 else '12' if rui_version == 3 else '13')
 
         #
         # @name(s): nvCarrer, partCarrier, localCarrier
         # @value(s): ro.build.oplus_nv_id
         #
-        if self.nvId != '0':
-            self.nvCarrier = self.partCarrier = self.localCarrier = self.nvId
+        if nvId and nvId != '0':
+            self.properties['nvCarrier'] =  self.properties['partCarrier'] = \
+                self.properties['localCarrier'] = nvId
         else:
-            self.nvCarrier = self.partCarrier = self.localCarrier = \
-                '10010111' if self.region == 1 else '00011011'
+            self.properties['nvCarrier'] = self.properties['partCarrier'] = \
+                self.properties['localCarrier'] = '10010111' if region == 1 else '01000100' if region == 3 else '00011011'
 
         #
         # @name(s): isRealme
         # @value(s): RMX -> 1
         #
-        self.isRealme = '1' if 'RMX' in self.model else '0'
+        self.properties['isRealme'] = '1' if 'RMX' in self.properties.get('model') else '0'
 
         #
         # @name(s): romPrefix, romVersion, otaPrefix
         # @value(s): ro.build.version.ota
         #
-        self.romPrefix = self.romVersion = \
-            self.otaPrefix = f'{self.otaVersion.split("_")[0]}_{self.otaVersion.split("_")[1]}'
+        self.properties['romPrefix'] = self.properties['romVersion'] = \
+            self.properties['otaPrefix'] = '_'.join(self.properties.get('otaVersion').split('_')[:2])
 
-        self.resp_key = 'resps' if self.rui_version == 1 else 'body'
+        self.resp_key = 'resps' if rui_version == 1 else 'body'
 
     def set_body(self):
+        new_body = dict()
         for entry in list(data.default_body.keys()):
-            try:
-                exec(f"data.default_body[\"{entry}\"] = self.{entry}")
-            except Exception:
-                pass
+            new_body[entry] = self.properties.get(entry) or data.default_body[entry]
 
-        if self.rui_version > 1:
-            self.body = {'params': self.encrypt(json.dumps(data.default_body)).decode("utf-8")}
-        else:
-            self.body = json.dumps({'params': self.encrypt(json.dumps(data.default_body))})
+        self.body = json.dumps({'params': self.encrypt(json.dumps(new_body))})
+        return new_body
 
     def set_hdrs(self):
         for entry in list(data.default_headers.keys()):
-            try:
-                if entry == "deviceId":
-                    exec(f"data.default_headers[\"{entry}\"] = crypto.sha256(self.{entry})")
-                else:
-                    exec(f"data.default_headers[\"{entry}\"] = self.{entry}")
-            except Exception:
-                pass
-
-        self.headers = data.default_headers
+            self.headers[entry] = self.properties.get(entry) or data.default_headers[entry]
+            if entry == "deviceId":
+                self.headers[entry] = crypto.sha256(self.headers[entry])
+        return self.headers
 
     def validate_response(self, response):
         if response.status_code != 200 or 'responseCode' in json.loads(response.content) and json.loads(response.content)['responseCode'] != 200:

--- a/realme_ota/utils/request.py
+++ b/realme_ota/utils/request.py
@@ -8,7 +8,7 @@ except ImportError:
     from realme_ota.utils import crypto
 
 class Request:
-    def __init__(self, model=None, ota_version=None, nv_identifier=None, rui_version=None, region=None, deviceId=None):
+    def __init__(self, model=None, ota_version=None, nv_identifier=None, rui_version=None, region=None, deviceId=None, imei0=None, imei1=None, beta=False):
         self.properties = {
             'model': model,
             'productName': model,
@@ -16,8 +16,12 @@ class Request:
             'otaVersion': ota_version,
             'rui_version': rui_version,
             'region': region,
-            'deviceId': deviceId
+            'deviceId': deviceId,
+            'imei': imei0,
+            'imei1': imei1
         }
+        if beta:
+            self.properties['mode'] = '1'
         self.body = None
         self.headers = dict()
         self.url = None


### PR DESCRIPTION
Sorry for the mess this PR is. I was working on multiple things at once and I wasn't able to untangle it. I just split it in two for reasons I'll explain shortly.

The bulk of the PR is in the first commit. It includes some bug fixes ('romPrefix' not being properly split, missing strings for Android 13), some additions (default nv_id for EU region) and some code refactoring to uniform the two different paths for Realme UI 1 and 2/3/4.
There's also the introduction of a verbosity level setting. It was not strictly necessary, but since I was going to add an option to dump the headers, I decided it was worth adding. And, as I said, now the headers and the unencrypted body are dumped, if the verbosity level is set sufficiently high.
Finally, there's the reorganization of the options. Two subgroups are added to separate request and output options from the positional arguments and the general options. This makes the help a lot clearer, especially if the other commit is going to be merged.

The second commit is experimental, because I was not able to test it. It is based on a speculation, because I noticed that changing the 'mode' from 0 to 1 gave me an error message about the IMEI not being in the test set.
I managed to contact a user in the beta program, and setting one or both the IMEIs gave the same error. What I've not tested is to:

- Set both the IMEIs and the GUID
- Set only the GUID

I think that at least one of the methods should work, but honesty I have no idea on how to test. Users are not willing to share their IMEIs for obvious reasons, and I got the stable Android 13 update on my phone (plus I'm from Europe, so no beta for me). In any case, maybe the ability to set the IMEI is worth keeping anyway.

If you have any question about the PR, feel free to ask.

EDIT: Just want to point out that the README needs to be changed if you're going to merge this.