### PR TITLE
Fix occasional error 500 (Unrecognized token)

### DIFF
--- a/realme_ota/utils/crypto.py
+++ b/realme_ota/utils/crypto.py
@@ -32,7 +32,7 @@ def getKey(key):
     return (keys[int(key[0])] + key[4:12]).encode('utf-8')
 
 def encrypt_ctr(buf):
-    key_pseudo = str(randint(0, 10)) + ''.join(choices(string.digits, k=14))
+    key_pseudo = str(randint(0, 9)) + ''.join(choices(string.digits, k=14))
     key_real = getKey(key_pseudo)
 
     ctr = Counter.new(128, initial_value=int.from_bytes(hashlib.md5(key_real).digest(), "big"))
@@ -51,7 +51,7 @@ def decrypt_ctr(buf):
     return cipher.decrypt(data).decode("utf-8")
 
 def encrypt_ecb(buf):
-    key_pseudo = str(randint(0, 10)) + ''.join(choices(string.ascii_letters + string.digits, k=14))
+    key_pseudo = str(randint(0, 9)) + ''.join(choices(string.ascii_letters + string.digits, k=14))
     key_real = getKey(key_pseudo)
 
     cipher = AES.new(key_real, AES.MODE_ECB)


### PR DESCRIPTION
As per **randint** documentation:

> Return a random integer N such that a <= N <= b.

We only have 10 keys, so sometimes garbage is sent to the server.