### PR TITLE
Update README to mention the HTTPS_PROXY environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ output options:
 
 ## Additional notes
 * If your request returns `flow limit` or status code `500`, try to wait a few minutes and then request again.
+* You can set the _HTTPS_PROXY_ environment variable to send the request via a proxy (useful if an update can't be found in your country).
 * Since Android 11 (RUI2), Realme started using components, which means you won't be able to get a full OTA link.
 * The `--beta` option might not work correctly, it has not been fully tested!
 


### PR DESCRIPTION
Sometimes the rollout of an update is stuck in some countries. Mention that you can use the HTTPS_PROXY environment variable to send the request from another country.