### PR TITLE
Add version 2 request support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pip3 install --upgrade git+https://github.com/R0rt1z2/realme-ota
 ## Usage
 ```bash
 usage: realme-ota [-h] [-v {0,1,2,3,4,5} | -s] [-r {0,1,2,3}] [-g GUID]
-               [-i IMEI [IMEI ...]] [-b] [-d DUMP] [-o ONLY]
+               [-i IMEI [IMEI ...]] [-b] [--old-method] [-d DUMP] [-o ONLY]
                product_model ota_version {1,2,3,4} [nv_identifier]
 
 positional arguments:
@@ -33,7 +33,7 @@ positional arguments:
   nv_identifier         NV (carrier) identifier (ro.build.oplus_nv_id) (if
                         none, provide 0 or omit).
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -v {0,1,2,3,4,5}, --verbosity {0,1,2,3,4,5}
                         Set the verbosity level. Range: 0 (no logging) to 5
@@ -51,6 +51,8 @@ request options:
   -i IMEI [IMEI ...], --imei IMEI [IMEI ...]
                         Specify one or two IMEIs for the request.
   -b, --beta            Try to get a test version (IMEI probably required).
+  --old-method          Use old method for the request (only applies if
+                        rui_version >= 2).
 
 output options:
   -d DUMP, --dump DUMP  Save request response into a file.

--- a/realme_ota/main.py
+++ b/realme_ota/main.py
@@ -79,12 +79,13 @@ def main():
     logger.log(f"Load payload for {args.product_model} (RealmeUI V{args.rui_version})")
     try:
         request.set_vars()
-        req_body, req_hdrs = request.set_body_headers()
+        req_body, req_hdrs, plain_body = request.set_body_headers()
     except Exception as e:
         logger.die(f"Something went wrong while setting the request variables :( ({e})!", 2)
     
     logger.log(f"Request headers:\n{json.dumps(req_hdrs, indent=4, sort_keys=True, ensure_ascii=False)}", 5)
-    logger.log(f"Request body:\n{json.dumps(req_body, indent=4, sort_keys=True, ensure_ascii=False)}", 5)
+    logger.log(f"Request body:\n{json.dumps(plain_body, indent=4, sort_keys=True, ensure_ascii=False)}", 5)
+    logger.log(f"Encrypted body:\n{json.dumps(req_body, indent=4, sort_keys=True, ensure_ascii=False)}", 5)
     
     logger.log("Wait for the endpoint to reply")
     try:

--- a/realme_ota/main.py
+++ b/realme_ota/main.py
@@ -51,6 +51,7 @@ def main():
     req_opts.add_argument("-g", "--guid", type=str, default="0", help="The guid of the third line in the file /data/system/openid_config.xml (only required to extract 'CBT' in China).")
     req_opts.add_argument("-i", "--imei", type=str, nargs='+', help="Specify one or two IMEIs for the request.")
     req_opts.add_argument("-b", "--beta", action='store_true', help="Try to get a test version (IMEI probably required).")
+    req_opts.add_argument("--old-method", action='store_true', help="Use old method for the request (only applies if rui_version >= 2).")
     # Output settings
     out_opts = parser.add_argument_group("output options")
     out_opts.add_argument("-d", "--dump", type=str, help="Save request response into a file.")
@@ -63,6 +64,7 @@ def main():
     )
 
     request = Request(
+        req_version = 1 if args.old_method else 2,
         model = args.product_model,
         ota_version = args.ota_version,
         rui_version = args.rui_version,
@@ -77,8 +79,7 @@ def main():
     logger.log(f"Load payload for {args.product_model} (RealmeUI V{args.rui_version})")
     try:
         request.set_vars()
-        req_hdrs = request.set_hdrs()
-        req_body = request.set_body()
+        req_body, req_hdrs = request.set_body_headers()
     except Exception as e:
         logger.die(f"Something went wrong while setting the request variables :( ({e})!", 2)
     
@@ -103,7 +104,9 @@ def main():
 
     logger.log("Let's rock")
     try:
-        content = json.loads(request.decrypt(json.loads(response.content)[request.resp_key]))
+        json_response = json.loads(response.content)
+        logger.log(f"Response:\n{json.dumps(json_response, indent=4, sort_keys=True, ensure_ascii=False)}", 5)
+        content = json.loads(request.decrypt(json_response[request.resp_key]))
     except Exception as e:
         logger.die(f"Something went wrong while parsing the response :( {e}!", 2)
 

--- a/realme_ota/utils/crypto.py
+++ b/realme_ota/utils/crypto.py
@@ -70,7 +70,7 @@ def encrypt_ctr_v2(data):
     key = getRandomKey()
     iv = getIV()
     encrypted = enc_AES_CTR(data.encode('utf-8'), key, iv)
-    return b64encode(encrypted).decode('utf-8'), b64encode(iv).decode('utf-8'), b64encode(key).decode('utf-8')
+    return b64encode(encrypted).decode('utf-8'), b64encode(key).decode('utf-8'), b64encode(iv).decode('utf-8')
 
 def decrypt_ctr_v2(data, key, iv):
     return dec_AES_CTR(b64decode(data.encode('utf-8')), b64decode(key.encode('utf-8')), b64decode(iv.encode('utf-8')))

--- a/realme_ota/utils/data.py
+++ b/realme_ota/utils/data.py
@@ -30,7 +30,9 @@ default_headers = {
     'imei'           : '000000000000000',  # IMEI
     'imei1'          : '000000000000000',  # IMEI
     'deviceId'       : '0',                # N/A
-    'mode'           : '0',                # N/A
+    'mode'           : 'client_auto',      # Known values: "manual", "client_auto", "server_auto"
+    'channel'        : 'pc',               # Update channel
+    'version'        : '1',                # Request version
     'Accept'         : 'application/json', # N/A
     'Content-Type'   : 'application/json', # N/A
     'User-Agent'     : 'NULL'              # N/A
@@ -49,7 +51,7 @@ default_body = {
     'trackRegion'    : 'unknown',          # ro.oppo.regionmark (RUI1)
     'imei'           : '000000000000000',  # IMEI
     'imei1'          : '000000000000000',  # IMEI
-    'mode'           : '0',                # N/A
+    'mode'           : '0',                # 0 for normal, 1 for beta
     'registrationId' : 'unknown',          # N/A
     'deviceId'       : '0',                # N/A
     'version'        : '3',                # N/A
@@ -84,5 +86,28 @@ urls = {
         1 : 'https://component-ota.coloros.com/update/v2',         # CN
         2 : 'https://component-ota-in.coloros.com/update/v2',      # IN
         3 : 'https://component-ota-eu.coloros.com/update/v2'       # EU
+    }
+}
+
+server_params = {
+    0 : {
+        'serverURL': 'https://component-otapc-sg.allawnos.com/update/v1',
+        'pubKey' : 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkA980wxi+eTGcFDiw2I6RrUeO4jL/Aj3Yw4dNuW7tYt+O1sRTHgrzxPD9SrOqzz7G0KgoSfdFHe3JVLPN+U1waK+T0HfLusVJshDaMrMiQFDUiKajb+QKr+bXQhVofH74fjat+oRJ8vjXARSpFk4/41x5j1Bt/2bHoqtdGPcUizZ4whMwzap+hzVlZgs7BNfepo24PWPRujsN3uopl+8u4HFpQDlQl7GdqDYDj2zNOHdFQI2UpSf0aIeKCKOpSKF72KDEESpJVQsqO4nxMwEi2jMujQeCHyTCjBZ+W35RzwT9+0pyZv8FB3c7FYY9FdF/+lvfax5mvFEBd9jO+dpMQIDAQAB',
+        'negotiationVersion' : '1615895993238'
+    },
+    1 : {
+        'serverURL': 'https://component-otapc-cn.allawntech.com/update/v1',
+        'pubKey' : 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApXYGXQpNL7gmMzzvajHaoZIHQQvBc2cOEhJc7/tsaO4sT0unoQnwQKfNQCuv7qC1Nu32eCLuewe9LSYhDXr9KSBWjOcCFXVXteLO9WCaAh5hwnUoP/5/Wz0jJwBA+yqs3AaGLA9wJ0+B2lB1vLE4FZNE7exUfwUc03fJxHG9nCLKjIZlrnAAHjRCd8mpnADwfkCEIPIGhnwq7pdkbamZcoZfZud1+fPsELviB9u447C6bKnTU4AaMcR9Y2/uI6TJUTcgyCp+ilgU0JxemrSIPFk3jbCbzamQ6Shkw/jDRzYoXpBRg/2QDkbq+j3ljInu0RHDfOeXf3VBfHSnQ66HCwIDAQAB',
+        'negotiationVersion' : '1615879139745'
+    },
+    2 : {
+        'serverURL': 'https://component-otapc-in.allawnos.com/update/v1',
+        'pubKey' : 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwYtghkzeStC9YvAwOQmWylbp74Tj8hhi3f9IlK7A/CWrGbLgzz/BeKxNb45zBN8pgaaEOwAJ1qZQV5G4nProWCPOP1ro1PkemFJvw/vzOOT5uN0ADnHDzZkZXCU/knxqUSfLcwQlHXsYhNsAm7uOKjY9YXF4zWzYN0eFPkML3Pj/zg7hl/ov9clB2VeyI1/blMHFfcNA/fvqDTENXcNBIhgJvXiCpLcZqp+aLZPC5AwY/sCb3j5jTWer0Rk0ZjQBZE1AncwYvUx4mA65U59cWpTyl4c47J29MsQ66hqWv6eBHlDNZSEsQpHePUqgsf7lmO5Wd7teB8ugQki2oz1Y5QIDAQAB',
+        'negotiationVersion' : '1615896309308'
+    },
+    3 : {
+        'serverURL': 'https://component-otapc-eu.allawnos.com/update/v1',
+        'pubKey' : 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAh8/EThsK3f0WyyPgrtXb/D0Xni6UZNppaQHUqHWo976cybl92VxmehE0ISObnxERaOtrlYmTPIxkVC9MMueDvTwZ1l0KxevZVKU0sJRxNR9AFcw6D7k9fPzzpNJmhSlhpNbt3BEepdgibdRZbacF3NWy3ejOYWHgxC+I/Vj1v7QU5gD+1OhgWeRDcwuV4nGY1ln2lvkRj8EiJYXfkSq/wUI5AvPdNXdEqwou4FBcf6mD84G8pKDyNTQwwuk9lvFlcq4mRqgYaFg9DAgpDgqVK4NTJWM7tQS1GZuRA6PhupfDqnQExyBFhzCefHkEhcFywNyxlPe953NWLFWwbGvFKwIDAQAB',
+        'negotiationVersion' : '1615897067573'
     }
 }

--- a/realme_ota/utils/request.py
+++ b/realme_ota/utils/request.py
@@ -26,7 +26,7 @@ except ImportError:
     from realme_ota.utils import crypto
 
 class Request:
-    def __init__(self, req_version = 1, model=None, ota_version=None, nv_identifier=None,
+    def __init__(self, req_version=1, model=None, ota_version=None, nv_identifier=None,
         rui_version=None, region=None, deviceId=None, imei0=None, imei1=None, beta=False):
         self.properties = {
             'model': model,

--- a/realme_ota/utils/request.py
+++ b/realme_ota/utils/request.py
@@ -156,7 +156,7 @@ class Request:
         if self.req_version == 2:
             self.headers['version'] = '2'
             
-            cipher, iv, self.key = self.encrypt(json.dumps(new_body))
+            cipher, self.key, iv = self.encrypt(json.dumps(new_body))
             self.body = json.dumps({'params': json.dumps({'cipher': cipher, 'iv': iv})})
             
             region = self.properties.get('region', 0)


### PR DESCRIPTION
This change has a little bit of a story behind. I discovered that there was a new request type when capturing the traffic from my phone. I wanted to know if the reason some updates were not showing up was some missing field in the body. Now I know that's not the case, but at the time I couldn't figure out what was going on.
But recently an official tool was released by realme to check for updates on your PC. It uses a companion app that gets installed on the phone to build the request, and then it sends it to the server. Conversely, when it gets the response, it sends it back to the phone to decrypt it. As a side note, turns out that the PC tool still doesn't completely solve the problem of phones not getting updates.
Starting from this tool, I decided to reverse engineer the new schema, and here we are.

While I was at it, I also refactored the code a little bit.

The new method works from ColorOS 11 onward (rui_version >= 2). I made it the default, but added an option to use the old one, just in case.

Now some things I discovered about the headers:

- **channel** is set to **pc** when using the desktop tool and other values don't seem to produce different results.
- **mode** specifies how we searched for update: the tool sets it to **manual**, and it's the same value the phone uses when manually searching for updates. Unfortunately, I discovered that sometimes it gives an older update, so I set it to one of the _auto_ ones (I don't know the difference between the two). Note that this is different to the **mode** body parameter.
- **version** sets the request version (1 for old method, 2 for new).

Finally a consideration about the URLs (extracted from the desktop tool): there doesn't seem to be a difference in the response with the other ones (they both respond the same on _/v1_, _/v2_ and even _/v3_), except for the change log. The old ones gives a brief description and a link to a page with the details. The new ones gives a link to a change log with the logo, summary and details in one page. Using the _--old-method_ option will of course use the old ones, so I think it's worth keeping both. I haven't tested if they work with OnePlus phones, though.

Of course feel free to ask any question or make changes to the PR.

EDIT: Forgot to specify that the servers of course still accept the old method, but I decided to implement the new one in case realme shuts down the support for the old one.